### PR TITLE
feature-verbose-post

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BASE_URL=http://host.docker.internal:3000
+WS_URL=http://host.docker.internal:4000
+ACCESS_TOKEN=LF10d788v8T26vEIDT1K1PrT-MLywyQf3NJejt35Y-8

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ build-iPhoneSimulator/
 # End of https://www.gitignore.io/api/git,osx,ruby,linux
 
 key.yml
+
+.env

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@ mastodon上で、俳句を検出するbotのプログラムです。日々のト
 
 ## 使い方
 1. mecabをなんとかして入れる
-2. 以下を参考に`key.yml`という設定ファイルを作成し、どうにかして`base_url`と`access_token`を入手して記載する
-```key.yml
-base_url: theboss.tech
-access_token: tx8j4j3yb5ibxuns6i3w73ndpffmg4c7jxcr7jr5psgn5de4a38k5d5jjc4tsir8
+2. 以下を参考に`.env`という設定ファイルを作成し、どうにかして`BASE_URL`と`ACCESS_TOKEN`を入手して記載する
+```env
+BASE_URL=https://example.com
+ACCESS_TOKEN=tx8j4j3yb5ibxuns6i3w73ndpffmg4c7jxcr7jr5psgn5de4a38k5d5jjc4tsir8
 ```
-3. `bundle install`
-4. `bundle exec ruby main.rb`
-5.  ✌('ω'✌ )三✌('ω')✌三( ✌'ω')✌
+3. `docker-compose up -d`
+4.  ✌('ω'✌ )三✌('ω')✌三( ✌'ω')✌
 
 ## 現状
 - 撥音とかがおかしい？

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    env_file:
+      - .env


### PR DESCRIPTION
検出時に検査の詳細をポストする機能を追加します。

![image](https://user-images.githubusercontent.com/30565780/83345903-f322a080-a352-11ea-91c2-c56709f15eeb.png)

- 詳細ポストは in_reply_id 有、 unlisted です。
- 環境変数 `BASE_URL` の形式が変わりますのでご注意ください。 (`example.com` から `https://example.com` に変更)
- 検査対象のアカウント ID が Bot 自身の ID と同じ場合はスキップする処理も追加しています。